### PR TITLE
Patch: don't use unshift

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module JMDict
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/lib/word.rb
+++ b/lib/word.rb
@@ -10,7 +10,7 @@ module JMDict
 
     def readings(**options)
       if options[:include_main]
-        @readings.unshift(@main)
+        [@main] + @readings
       else
         @readings
       end


### PR DESCRIPTION
Unshift doesn't return a copy. Calling `#readings` with `include_main: true` then calling `#readings` again would include the main reading. Calling it again with `include_main: true` would add another instance of the main reading to the list.

Signed-off-by: sleepydeveloper <sleepydeveloper@gmail.com>